### PR TITLE
Support interface-based IP lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,31 @@ or:
 ```
 -i {AccessId} -k {AccessKey} -m {MainDomain} -s {SubDomainName} -c {CheckUpdateInterval}
 
+## Config
+
+```yaml
+accessid: '*AccessId'
+accesskey: '*AccessKey'
+maindomain: '*example.com'
+subdomainname: '*www'
+checkupdateinterval: 30
+protocol: all
+ipv4apiurl: ""
+ipv6apiurl: ""
+ipv4interfacename: ""
+ipv6interfacename: ""
+```
+
+`ipv4interfacename` and `ipv6interfacename` can be configured separately.
+When an interface name is set, aliddns reads the IP from the local network
+interface first instead of querying the configured API URL. For example:
+
+```yaml
+protocol: all
+ipv4interfacename: eth0
+ipv6interfacename: eth1
+```
+
 You can install the pre-compiled binary (in several different ways),
 use Docker.
 
@@ -94,4 +119,3 @@ $ docker run openiothub/aliddns:latest run -i myid -k mykey -m iothub.cloud -s w
 Note that the image will almost always have the last stable Go version.
 
 [releases]: https://github.com/OpenIoTHub/aliddns/releases
-

--- a/aliddns.yaml
+++ b/aliddns.yaml
@@ -6,3 +6,5 @@ checkupdateinterval: 30
 protocol: all
 ipv4apiurl: ""
 ipv6apiurl: ""
+ipv4interfacename: ""
+ipv6interfacename: ""

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,8 @@ var ConfigModel = &models.ConfigModel{
 	Protocol:            "all",
 	Ipv4ApiUrl:          "",
 	Ipv6ApiUrl:          "",
+	Ipv4InterfaceName:   "",
+	Ipv6InterfaceName:   "",
 }
 
 // 将配置写入指定的路径的文件
@@ -70,6 +72,7 @@ func UseConfigFile() {
 	protocol := strings.ToLower(ConfigModel.Protocol)
 	for _, val := range SupportedProtocols {
 		if val == protocol {
+			ConfigModel.Protocol = protocol
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -113,6 +113,20 @@ func main() {
 					EnvVars:     []string{"Ipv6ApiUrl"},
 					Destination: &config.ConfigModel.Ipv6ApiUrl,
 				},
+				&cli.StringFlag{
+					Name:        "ipv4InterfaceName",
+					Value:       config.ConfigModel.Ipv4InterfaceName,
+					Usage:       "Ipv4InterfaceName",
+					EnvVars:     []string{"Ipv4InterfaceName"},
+					Destination: &config.ConfigModel.Ipv4InterfaceName,
+				},
+				&cli.StringFlag{
+					Name:        "ipv6InterfaceName",
+					Value:       config.ConfigModel.Ipv6InterfaceName,
+					Usage:       "Ipv6InterfaceName",
+					EnvVars:     []string{"Ipv6InterfaceName"},
+					Destination: &config.ConfigModel.Ipv6InterfaceName,
+				},
 			},
 			Action: func(c *cli.Context) error {
 				return timerFunction()
@@ -219,7 +233,7 @@ func update() {
 	//}
 
 	// 如果没有相应记录，又想要更新，那就新建一个
-	if !ipv4Finded && (protocol == "ipv4" || protocol == "all") {
+	if !ipv4Finded && publicIpv4 != "" && (protocol == "ipv4" || protocol == "all") {
 		var sub = &alidns.Record{
 			DomainName: config.ConfigModel.MainDomain,
 			RR:         config.ConfigModel.SubDomainName,
@@ -230,7 +244,7 @@ func update() {
 		log.Println("未找到 IPv4 记录，现尝试创建一个")
 		_ = utils.AddSubDomainRecord(sub)
 	}
-	if !ipv6Finded && (protocol == "ipv6" || protocol == "all") {
+	if !ipv6Finded && publicIpv6 != "" && (protocol == "ipv6" || protocol == "all") {
 		var sub = &alidns.Record{
 			DomainName: config.ConfigModel.MainDomain,
 			RR:         config.ConfigModel.SubDomainName,

--- a/models/models.go
+++ b/models/models.go
@@ -9,4 +9,6 @@ type ConfigModel struct {
 	Protocol            string // "ipv4"或"ipv6"或"all"，默认"all"
 	Ipv4ApiUrl          string // 获取 IPv4 的 API 地址
 	Ipv6ApiUrl          string // 获取 IPv6 的 API 地址
+	Ipv4InterfaceName   string // 获取 IPv4 的网卡名称，设置后优先从本机网卡获取
+	Ipv6InterfaceName   string // 获取 IPv6 的网卡名称，设置后优先从本机网卡获取
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,15 +1,16 @@
 package utils
 
 import (
-	"github.com/OpenIoTHub/aliddns/config"
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
-	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
+	"fmt"
 	"io"
 	"log"
 	"net"
 	"net/http"
-	"regexp"
 	"strings"
+
+	"github.com/OpenIoTHub/aliddns/config"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
 )
 
 //u4="http://ipv4.ident.me http://ipv4.icanhazip.com http://nsupdate.info/myip http://whatismyip.akamai.com http://ipv4.myip.dk/api/info/IPv4Address http://checkip4.spdyn.de http://v4.ipv6-test.com/api/myip.php http://checkip.amazonaws.com http://ipinfo.io/ip http://bot.whatismyipaddress.com http://ipv4.ident.me http://ipv4.icanhazip.com http://nsupdate.info/myip http://whatismyip.akamai.com http://ipv4.myip.dk/api/info/IPv4Address http://checkip4.spdyn.de http://v4.ipv6-test.com/api/myip.php http://checkip.amazonaws.com http://ipinfo.io/ip http://bot.whatismyipaddress.com"
@@ -44,10 +45,21 @@ var Ipv6APIUrls = []string{
 }
 
 func GetMyPublicIpv4() string {
-	if config.ConfigModel.Ipv4ApiUrl != "" {
-		Ipv4APIUrls = append([]string{config.ConfigModel.Ipv4ApiUrl}, Ipv4APIUrls...)
+	interfaceName := strings.TrimSpace(config.ConfigModel.Ipv4InterfaceName)
+	if interfaceName != "" {
+		ipv4, err := GetIPByInterface(interfaceName, "ipv4")
+		if err != nil {
+			log.Printf("get ipv4 from interface err：%s", err)
+			return ""
+		}
+		log.Printf("got ipv4 addr from interface %s: %s", interfaceName, ipv4)
+		return ipv4
 	}
-	for _, url := range Ipv4APIUrls {
+	urls := Ipv4APIUrls
+	if apiURL := strings.TrimSpace(config.ConfigModel.Ipv4ApiUrl); apiURL != "" {
+		urls = append([]string{apiURL}, Ipv4APIUrls...)
+	}
+	for _, url := range urls {
 		resp, err := http.Get(url)
 		if err != nil {
 			log.Printf("get public ipv4 err：%s", err)
@@ -59,22 +71,34 @@ func GetMyPublicIpv4() string {
 			_ = resp.Body.Close()
 			continue
 		}
-		ipv4 := strings.Replace(string(bytes), "\n", "", -1)
+		ipv4 := strings.TrimSpace(string(bytes))
 		ip := net.ParseIP(ipv4)
 		if ip != nil {
 			log.Println("got ipv4 addr:", ip.String())
 			_ = resp.Body.Close()
 			return ip.String()
 		}
+		_ = resp.Body.Close()
 	}
 	return ""
 }
 
 func GetMyPublicIpv6() string {
-	if config.ConfigModel.Ipv6ApiUrl != "" {
-		Ipv6APIUrls = append([]string{config.ConfigModel.Ipv6ApiUrl}, Ipv6APIUrls...)
+	interfaceName := strings.TrimSpace(config.ConfigModel.Ipv6InterfaceName)
+	if interfaceName != "" {
+		ipv6, err := GetIPByInterface(interfaceName, "ipv6")
+		if err != nil {
+			log.Printf("get ipv6 from interface err：%s", err)
+			return ""
+		}
+		log.Printf("got ipv6 addr from interface %s: %s", interfaceName, ipv6)
+		return ipv6
 	}
-	for _, url := range Ipv6APIUrls {
+	urls := Ipv6APIUrls
+	if apiURL := strings.TrimSpace(config.ConfigModel.Ipv6ApiUrl); apiURL != "" {
+		urls = append([]string{apiURL}, Ipv6APIUrls...)
+	}
+	for _, url := range urls {
 		resp, err := http.Get(url)
 		if err != nil {
 			log.Printf("get public ipv6 err：%s", err)
@@ -90,30 +114,70 @@ func GetMyPublicIpv6() string {
 		// 删除 document.write(xxx) (如有)
 		tmp := strings.Replace(string(bytes), "document.write('", "", -1)
 		tmp = strings.Replace(tmp, "');", "", -1)
-		ipv6 := strings.Replace(tmp, "\n", "", -1)
+		ipv6 := strings.TrimSpace(tmp)
 		ip := net.ParseIP(ipv6)
 		if ip != nil {
 			log.Println("got ipv6 addr:", ip.String())
 			_ = resp.Body.Close()
 			return ip.String()
 		}
+		_ = resp.Body.Close()
 	}
 	return ""
 }
 
-// GetMyIPV6ByLocal TODO Test
-func GetMyIPV6ByLocal() string {
-	s, err := net.InterfaceAddrs()
+func GetIPByInterface(interfaceName, protocol string) (string, error) {
+	networkInterface, err := net.InterfaceByName(strings.TrimSpace(interfaceName))
 	if err != nil {
-		return ""
+		return "", err
 	}
-	for _, a := range s {
-		i := regexp.MustCompile(`(\w+:){7}\w+`).FindString(a.String())
-		if strings.Count(i, ":") == 7 {
-			return i
+	if networkInterface.Flags&net.FlagUp == 0 {
+		return "", fmt.Errorf("network interface %q is down", networkInterface.Name)
+	}
+	addrs, err := networkInterface.Addrs()
+	if err != nil {
+		return "", err
+	}
+	for _, addr := range addrs {
+		ip := getIPFromInterfaceAddr(addr)
+		if ip == nil || !isUsableInterfaceIP(ip) {
+			continue
+		}
+		switch protocol {
+		case "ipv4":
+			ipv4 := ip.To4()
+			if ipv4 != nil {
+				return ipv4.String(), nil
+			}
+		case "ipv6":
+			if ip.To4() == nil && ip.To16() != nil {
+				return ip.String(), nil
+			}
+		default:
+			return "", fmt.Errorf("unsupported protocol %q", protocol)
 		}
 	}
-	return ""
+	return "", fmt.Errorf("no usable %s address found on interface %q", protocol, networkInterface.Name)
+}
+
+func getIPFromInterfaceAddr(addr net.Addr) net.IP {
+	switch v := addr.(type) {
+	case *net.IPAddr:
+		return v.IP
+	case *net.IPNet:
+		return v.IP
+	default:
+		return nil
+	}
+}
+
+func isUsableInterfaceIP(ip net.IP) bool {
+	return ip.IsGlobalUnicast() &&
+		!ip.IsLoopback() &&
+		!ip.IsLinkLocalUnicast() &&
+		!ip.IsLinkLocalMulticast() &&
+		!ip.IsMulticast() &&
+		!ip.IsUnspecified()
 }
 
 func GetSubDomains(mainDomian string) (*alidns.DescribeDomainRecordsResponse, error) {


### PR DESCRIPTION
支持直接使用本机指定网卡的 ip 作为 dns 解析的地址，用于解决多网卡环境下，不能正确获取 ip 的问题。

通过网卡获取ip 是一个可选功能，设置了网卡名称以后，将不使用 url 探测本机ip。
